### PR TITLE
Migrate biome config to v2

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
 	"vcs": {
 		"enabled": false,
 		"clientKind": "git",
@@ -7,15 +7,18 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"ignore": [".output/*", ".wxt/*", "node_modules/*"]
+		"includes": [
+			"**",
+			"!**/.output/**/*",
+			"!**/.wxt/**/*",
+			"!**/node_modules/**/*"
+		]
 	},
 	"formatter": {
 		"enabled": true,
 		"indentStyle": "tab"
 	},
-	"organizeImports": {
-		"enabled": true
-	},
+	"assist": { "actions": { "source": { "organizeImports": "on" } } },
 	"linter": {
 		"enabled": true,
 		"rules": {


### PR DESCRIPTION
## Summary
- Biome設定ファイルをv1からv2形式にマイグレーション
- `$schema`をv2.4.9に更新、`files.ignore`を`files.includes`に変換、`organizeImports`を`assist.actions.source`に移動

## Test plan
- [ ] `pnpm biome check` が正常に動作すること
- [ ] `pnpm lint` / `pnpm format` が期待通り動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)