### PR TITLE
App.tsx の責務分割・API URL定数化・URL二重パース解消

### DIFF
--- a/entrypoints/background/index.ts
+++ b/entrypoints/background/index.ts
@@ -1,9 +1,11 @@
 import type { CreateUserBody } from "@/model/circle_model";
 import { onMessage } from "../messaging/messaging";
 
+const API_BASE_URL = "http://localhost:3000";
+
 async function handleCreateUser(body: CreateUserBody) {
 	try {
-		const response = await fetch("http://localhost:3000/users", {
+		const response = await fetch(`${API_BASE_URL}/users`, {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",

--- a/entrypoints/content/index.tsx
+++ b/entrypoints/content/index.tsx
@@ -27,26 +27,23 @@ const extractLinks = (): Link[] => {
 		document.getElementsByClassName("item")[0].getElementsByTagName("a"),
 	);
 
-	return links
-		.filter((link) => {
-			try {
-				const url = new URL(link.href);
-				return getPlatformByDomain(url.hostname);
-			} catch (e) {
-				console.log(e);
-				return false;
-			}
-		})
-		.map((link) => {
+	return links.flatMap((link) => {
+		try {
 			const url = new URL(link.href);
-			const newLink: Link = {
-				service: getPlatformByDomain(url.hostname),
-				href: link.href,
-				text: link?.textContent?.trim() || link.href,
-			};
-
-			return newLink;
-		});
+			const service = getPlatformByDomain(url.hostname);
+			if (!service) return [];
+			return [
+				{
+					service,
+					href: link.href,
+					text: link?.textContent?.trim() || link.href,
+				},
+			];
+		} catch (e) {
+			console.log(e);
+			return [];
+		}
+	});
 };
 
 // 最初に実行される

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -1,154 +1,50 @@
-import { useState } from "react";
 import "./App.css";
-import { sendMessage } from "../messaging/messaging";
-import {
-	extractCircleID,
-	type Platform,
-	PlatformList,
-} from "douhin_extraction";
-import type { CircleInfo, CreateUserBody, Link } from "@/model/circle_model";
 import { CircleLinks } from "@/components/circle-links";
+import { useCircleExtraction } from "./useCircleExtraction";
 
 function App() {
-	const [result, setResult] = useState("");
-	const [circleInfo, setCircleInfo] = useState<CircleInfo>();
-
-	// リンクの中でサークル情報に対するリンクのみ残す、サービス情報を付与する(それ以外のリンクは後でfilterする)
-	const filterCircleLink = (link: Link): boolean => {
-		if (!link.service) {
-			return false;
-		}
-
-		const platform = link.service;
-		const cicrleID = extractCircleID(platform, link.href);
-
-		if (!cicrleID) {
-			return false;
-		}
-
-		return true;
-	};
-
-	// Todo: circle.msだけじゃなくskeb,fantia,fanboxからリンクを取り出せるようにしたい
-	const extractLinks = async () => {
-		const activeTab = await browser.tabs.query({
-			active: true,
-			lastFocusedWindow: true,
-		});
-
-		const isCircleMS = await sendMessage(
-			"isCircleMS",
-			undefined,
-			activeTab[0].id,
-		);
-
-		if (!isCircleMS) {
-			setResult("circle.ms上で実行してください");
-			return;
-		}
-
-		try {
-			const info = await sendMessage(
-				"getCircleInfo",
-				undefined,
-				activeTab[0].id,
-			);
-			info.links = info.links.filter((link) => filterCircleLink(link));
-
-			if (info.links.length === 0) {
-				setResult("該当するリンクが見つかりませんでした");
-			}
-
-			// ここまで残ったリンクはsummaryとして表示し、さらにAppに送信する元データとしても使う
-			setCircleInfo(info);
-		} catch (e) {
-			console.log(e);
-			setResult(`ページの解析中にエラー発生しました。${e}`);
-		}
-	};
-
-	const copyLinksSummary = () => {
-		navigator.clipboard.writeText(JSON.stringify(circleInfo));
-	};
-
-	const sendApp = async () => {
-		if (circleInfo === undefined) {
-			setResult("送信できるサークル情報がありません");
-			return;
-		}
-
-		// keyをserviceとしたhashに変換
-		const linkHash: Record<Platform, Link> = Object.fromEntries(
-			circleInfo.links.map((item) => [item.service, item]),
-		);
-
-		const getID = (platform: Platform): string | null => {
-			if (!Object.hasOwn(linkHash, platform)) {
-				return null;
-			}
-
-			return extractCircleID(platform, linkHash[platform].href) || null;
-		};
-
-		const body: CreateUserBody = {
-			name: circleInfo.circleName,
-			melonbooksId: getID(PlatformList.melonbooks),
-			fanzaId: getID(PlatformList.fanza),
-			dlsiteId: getID(PlatformList.dlsite),
-			twitterId: getID(PlatformList.twitter),
-			pixivId: getID(PlatformList.pixiv),
-		};
-
-		console.log(body);
-
-		const sendResult = await sendMessage("createUser", body);
-
-		sendResult
-			? setResult("Appへ送信しました")
-			: setResult("Appへの送信エラーになりました");
-	};
+	const { result, circleInfo, extractLinks, copyLinksSummary, sendApp } =
+		useCircleExtraction();
 
 	return (
-		<>
+		<div>
+			<button type="button" id="extract" onClick={extractLinks}>
+				生成
+			</button>
+			<textarea
+				id="result_area"
+				name="result_area"
+				cols={30}
+				rows={5}
+				value={JSON.stringify(circleInfo)}
+				readOnly
+			/>
+
+			{result && (
+				<div id="result_message">
+					<p>{result}</p>
+				</div>
+			)}
 			<div>
-				<button type="button" id="extract" onClick={extractLinks}>
-					生成
+				<button type="button" id="copy" onClick={copyLinksSummary}>
+					コピー
 				</button>
-				<textarea
-					id="result_area"
-					name="result_area"
-					cols={30}
-					rows={5}
-					value={JSON.stringify(circleInfo)}
-					readOnly
-				/>
-
-				{result && (
-					<div id="result_message">
-						<p>{result}</p>
-					</div>
-				)}
-				<div>
-					<button type="button" id="copy" onClick={copyLinksSummary}>
-						コピー
-					</button>
-					<button
-						type="button"
-						id="post_dj"
-						hidden={!circleInfo}
-						onClick={sendApp}
-					>
-						Appに送信
-					</button>
-				</div>
-
-				<div id="links" className="link-item">
-					{circleInfo && circleInfo.links.length > 0 && (
-						<CircleLinks links={circleInfo.links} />
-					)}
-				</div>
+				<button
+					type="button"
+					id="post_dj"
+					hidden={!circleInfo}
+					onClick={sendApp}
+				>
+					Appに送信
+				</button>
 			</div>
-		</>
+
+			<div id="links" className="link-item">
+				{circleInfo && circleInfo.links.length > 0 && (
+					<CircleLinks links={circleInfo.links} />
+				)}
+			</div>
+		</div>
 	);
 }
 

--- a/entrypoints/popup/useCircleExtraction.ts
+++ b/entrypoints/popup/useCircleExtraction.ts
@@ -1,0 +1,102 @@
+import { useState } from "react";
+import { sendMessage } from "../messaging/messaging";
+import {
+	extractCircleID,
+	type Platform,
+	PlatformList,
+} from "douhin_extraction";
+import type { CircleInfo, CreateUserBody, Link } from "@/model/circle_model";
+
+function filterCircleLink(link: Link): boolean {
+	if (!link.service) {
+		return false;
+	}
+
+	return !!extractCircleID(link.service, link.href);
+}
+
+export function useCircleExtraction() {
+	const [result, setResult] = useState("");
+	const [circleInfo, setCircleInfo] = useState<CircleInfo>();
+
+	// Todo: circle.msだけじゃなくskeb,fantia,fanboxからリンクを取り出せるようにしたい
+	const extractLinks = async () => {
+		const activeTab = await browser.tabs.query({
+			active: true,
+			lastFocusedWindow: true,
+		});
+
+		const isCircleMS = await sendMessage(
+			"isCircleMS",
+			undefined,
+			activeTab[0].id,
+		);
+
+		if (!isCircleMS) {
+			setResult("circle.ms上で実行してください");
+			return;
+		}
+
+		try {
+			const info = await sendMessage(
+				"getCircleInfo",
+				undefined,
+				activeTab[0].id,
+			);
+			info.links = info.links.filter((link) => filterCircleLink(link));
+
+			if (info.links.length === 0) {
+				setResult("該当するリンクが見つかりませんでした");
+			}
+
+			// ここまで残ったリンクはsummaryとして表示し、さらにAppに送信する元データとしても使う
+			setCircleInfo(info);
+		} catch (e) {
+			console.log(e);
+			setResult(`ページの解析中にエラー発生しました。${e}`);
+		}
+	};
+
+	const copyLinksSummary = () => {
+		navigator.clipboard.writeText(JSON.stringify(circleInfo));
+	};
+
+	const sendApp = async () => {
+		if (circleInfo === undefined) {
+			setResult("送信できるサークル情報がありません");
+			return;
+		}
+
+		// keyをserviceとしたhashに変換
+		const linkHash: Record<Platform, Link> = Object.fromEntries(
+			circleInfo.links.map((item) => [item.service, item]),
+		);
+
+		const getID = (platform: Platform): string | null => {
+			if (!Object.hasOwn(linkHash, platform)) {
+				return null;
+			}
+
+			return extractCircleID(platform, linkHash[platform].href) || null;
+		};
+
+		const body: CreateUserBody = {
+			name: circleInfo.circleName,
+			melonbooksId: getID(PlatformList.melonbooks),
+			fanzaId: getID(PlatformList.fanza),
+			dlsiteId: getID(PlatformList.dlsite),
+			twitterId: getID(PlatformList.twitter),
+			pixivId: getID(PlatformList.pixiv),
+		};
+
+		console.log(body);
+
+		const sendResult = await sendMessage("createUser", body);
+
+		sendResult
+			? setResult("Appへ送信しました")
+			: setResult("Appへの送信エラーになりました");
+	};
+
+	return { result, circleInfo, extractLinks, copyLinksSummary, sendApp };
+}


### PR DESCRIPTION
- App.tsx からロジックを useCircleExtraction カスタムフックに分離
- filterCircleLink をフック外の純粋関数に移動
- background/index.ts の API URL を定数 API_BASE_URL に切り出し
- content/index.tsx の filter+map を flatMap に統合し new URL() を1回に削減