### PR TITLE
feat: ドメイン単位で関連ページを登録しポップアップに表示する機能を追加

### DIFF
--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -1,0 +1,203 @@
+import { useEffect, useState } from "react";
+import type { RelatedLink, RelatedPageRule } from "@/model/related_pages_model";
+import { RELATED_PAGE_RULES_KEY } from "@/model/related_pages_model";
+
+async function loadRules(): Promise<RelatedPageRule[]> {
+	const result = await browser.storage.local.get(RELATED_PAGE_RULES_KEY);
+	const data = result[RELATED_PAGE_RULES_KEY];
+	return Array.isArray(data) ? data : [];
+}
+
+async function saveRules(rules: RelatedPageRule[]): Promise<void> {
+	await browser.storage.local.set({ [RELATED_PAGE_RULES_KEY]: rules });
+}
+
+function isValidUrl(url: string): boolean {
+	try {
+		const parsed = new URL(url);
+		return parsed.protocol === "https:" || parsed.protocol === "http:";
+	} catch {
+		return false;
+	}
+}
+
+function isValidDomain(domain: string): boolean {
+	try {
+		return new URL(`https://${domain}`).hostname === domain;
+	} catch {
+		return false;
+	}
+}
+
+function App() {
+	const [rules, setRules] = useState<RelatedPageRule[]>([]);
+	const [newDomain, setNewDomain] = useState("");
+	const [error, setError] = useState("");
+	const [newLinkInputs, setNewLinkInputs] = useState<
+		Record<string, { label: string; url: string }>
+	>({});
+
+	useEffect(() => {
+		loadRules().then(setRules);
+	}, []);
+
+	async function updateAndSave(updated: RelatedPageRule[]) {
+		try {
+			await saveRules(updated);
+			setRules(updated);
+			setError("");
+		} catch (e) {
+			console.error("ルールの保存に失敗しました:", e);
+			setError("保存に失敗しました");
+		}
+	}
+
+	function addDomain() {
+		const domain = newDomain.trim();
+		if (!domain || !isValidDomain(domain)) return;
+		if (rules.some((r) => r.domain === domain)) return;
+		updateAndSave([...rules, { domain, links: [] }]);
+		setNewDomain("");
+	}
+
+	function removeDomain(domain: string) {
+		updateAndSave(rules.filter((r) => r.domain !== domain));
+	}
+
+	function addLink(domain: string) {
+		const input = newLinkInputs[domain];
+		if (!input?.label.trim() || !input?.url.trim()) return;
+		if (!isValidUrl(input.url.trim())) return;
+		const updated = rules.map((r) => {
+			if (r.domain !== domain) return r;
+			const newLink: RelatedLink = {
+				label: input.label.trim(),
+				url: input.url.trim(),
+			};
+			return { ...r, links: [...r.links, newLink] };
+		});
+		updateAndSave(updated);
+		setNewLinkInputs((prev) => ({
+			...prev,
+			[domain]: { label: "", url: "" },
+		}));
+	}
+
+	function removeLink(domain: string, url: string) {
+		const updated = rules.map((r) => {
+			if (r.domain !== domain) return r;
+			return { ...r, links: r.links.filter((l) => l.url !== url) };
+		});
+		updateAndSave(updated);
+	}
+
+	function updateLinkInput(
+		domain: string,
+		field: "label" | "url",
+		value: string,
+	) {
+		setNewLinkInputs((prev) => ({
+			...prev,
+			[domain]: { ...prev[domain], [field]: value },
+		}));
+	}
+
+	return (
+		<div style={{ padding: "16px", maxWidth: "600px", margin: "0 auto" }}>
+			<h1>関連ページ設定</h1>
+
+			{error && <p style={{ color: "red" }}>{error}</p>}
+
+			{rules.map((rule) => (
+				<div
+					key={rule.domain}
+					style={{
+						border: "1px solid #ccc",
+						borderRadius: "4px",
+						padding: "12px",
+						marginBottom: "12px",
+					}}
+				>
+					<div
+						style={{
+							display: "flex",
+							justifyContent: "space-between",
+							alignItems: "center",
+						}}
+					>
+						<strong>{rule.domain}</strong>
+						<button
+							type="button"
+							onClick={() => removeDomain(rule.domain)}
+						>
+							ドメインを削除
+						</button>
+					</div>
+
+					<ul style={{ paddingLeft: "16px" }}>
+						{rule.links.map((link) => (
+							<li
+								key={link.url}
+								style={{
+									display: "flex",
+									justifyContent: "space-between",
+									alignItems: "center",
+									marginBottom: "4px",
+								}}
+							>
+								<span>
+									{link.label} — {link.url}
+								</span>
+								<button
+									type="button"
+									onClick={() =>
+										removeLink(rule.domain, link.url)
+									}
+								>
+									削除
+								</button>
+							</li>
+						))}
+					</ul>
+
+					<div style={{ display: "flex", gap: "8px", marginTop: "8px" }}>
+						<input
+							type="text"
+							placeholder="ラベル"
+							value={newLinkInputs[rule.domain]?.label ?? ""}
+							onChange={(e) =>
+								updateLinkInput(rule.domain, "label", e.target.value)
+							}
+						/>
+						<input
+							type="url"
+							placeholder="URL"
+							value={newLinkInputs[rule.domain]?.url ?? ""}
+							onChange={(e) =>
+								updateLinkInput(rule.domain, "url", e.target.value)
+							}
+						/>
+						<button type="button" onClick={() => addLink(rule.domain)}>
+							追加
+						</button>
+					</div>
+				</div>
+			))}
+
+			<div style={{ display: "flex", gap: "8px", marginTop: "16px" }}>
+				<input
+					type="text"
+					placeholder="example.com"
+					value={newDomain}
+					onChange={(e) => setNewDomain(e.target.value)}
+					onKeyDown={(e) => e.key === "Enter" && addDomain()}
+				/>
+				<button type="button" onClick={addDomain}>
+					ドメインを追加
+				</button>
+			</div>
+		</div>
+	);
+}
+
+export default App;

--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -126,10 +126,7 @@ function App() {
 						}}
 					>
 						<strong>{rule.domain}</strong>
-						<button
-							type="button"
-							onClick={() => removeDomain(rule.domain)}
-						>
+						<button type="button" onClick={() => removeDomain(rule.domain)}>
 							ドメインを削除
 						</button>
 					</div>
@@ -150,9 +147,7 @@ function App() {
 								</span>
 								<button
 									type="button"
-									onClick={() =>
-										removeLink(rule.domain, link.url)
-									}
+									onClick={() => removeLink(rule.domain, link.url)}
 								>
 									削除
 								</button>

--- a/entrypoints/options/index.html
+++ b/entrypoints/options/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>関連ページ設定</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="./main.tsx"></script>
+</body>
+</html>

--- a/entrypoints/options/main.tsx
+++ b/entrypoints/options/main.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App.tsx";
+
+const rootElement = document.getElementById("root");
+if (rootElement) {
+	ReactDOM.createRoot(rootElement).render(
+		<React.StrictMode>
+			<App />
+		</React.StrictMode>,
+	);
+} else {
+	throw new Error("Root element not found");
+}

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -1,10 +1,12 @@
 import "./App.css";
 import { CircleLinks } from "@/components/circle-links";
 import { useCircleExtraction } from "./useCircleExtraction";
+import { useRelatedPages } from "./useRelatedPages";
 
 function App() {
 	const { result, circleInfo, extractLinks, copyLinksSummary, sendApp } =
 		useCircleExtraction();
+	const { relatedLinks } = useRelatedPages();
 
 	return (
 		<div>
@@ -44,6 +46,25 @@ function App() {
 					<CircleLinks links={circleInfo.links} />
 				)}
 			</div>
+
+			{relatedLinks.length > 0 && (
+				<div id="related-pages">
+					<h3>関連ページ</h3>
+					<ul>
+						{relatedLinks.map((link) => (
+							<li key={link.url} className="link-item">
+								<a
+									href={link.url}
+									target="_blank"
+									rel="noreferrer"
+								>
+									{link.label}
+								</a>
+							</li>
+						))}
+					</ul>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -53,11 +53,7 @@ function App() {
 					<ul>
 						{relatedLinks.map((link) => (
 							<li key={link.url} className="link-item">
-								<a
-									href={link.url}
-									target="_blank"
-									rel="noreferrer"
-								>
+								<a href={link.url} target="_blank" rel="noreferrer">
 									{link.label}
 								</a>
 							</li>

--- a/entrypoints/popup/useRelatedPages.ts
+++ b/entrypoints/popup/useRelatedPages.ts
@@ -22,8 +22,7 @@ export function useRelatedPages() {
 					return;
 				}
 
-				const result =
-					await browser.storage.local.get(RELATED_PAGE_RULES_KEY);
+				const result = await browser.storage.local.get(RELATED_PAGE_RULES_KEY);
 				const data = result[RELATED_PAGE_RULES_KEY];
 				if (!Array.isArray(data)) return;
 				const rules = data as RelatedPageRule[];

--- a/entrypoints/popup/useRelatedPages.ts
+++ b/entrypoints/popup/useRelatedPages.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+import type { RelatedLink, RelatedPageRule } from "@/model/related_pages_model";
+import { RELATED_PAGE_RULES_KEY } from "@/model/related_pages_model";
+
+export function useRelatedPages() {
+	const [relatedLinks, setRelatedLinks] = useState<RelatedLink[]>([]);
+
+	useEffect(() => {
+		(async () => {
+			try {
+				const tabs = await browser.tabs.query({
+					active: true,
+					currentWindow: true,
+				});
+				const url = tabs[0]?.url;
+				if (!url) return;
+
+				let hostname: string;
+				try {
+					hostname = new URL(url).hostname;
+				} catch {
+					return;
+				}
+
+				const result =
+					await browser.storage.local.get(RELATED_PAGE_RULES_KEY);
+				const data = result[RELATED_PAGE_RULES_KEY];
+				if (!Array.isArray(data)) return;
+				const rules = data as RelatedPageRule[];
+				const matched = rules.find((r) => r.domain === hostname);
+				if (matched) {
+					setRelatedLinks(matched.links);
+				}
+			} catch (e) {
+				console.error("関連ページの読み込みに失敗しました:", e);
+			}
+		})();
+	}, []);
+
+	return { relatedLinks };
+}

--- a/model/related_pages_model.ts
+++ b/model/related_pages_model.ts
@@ -1,0 +1,11 @@
+export const RELATED_PAGE_RULES_KEY = "relatedPageRules";
+
+export type RelatedLink = {
+	url: string;
+	label: string;
+};
+
+export type RelatedPageRule = {
+	domain: string;
+	links: RelatedLink[];
+};


### PR DESCRIPTION
## Summary
- ドメインと関連 URL（ラベル付き）を管理する options page を新規追加
- ポップアップで現在のタブのドメインを検出し、登録済み関連リンクを表示
- URL は `http:`/`https:` のみ許可するバリデーション、ストレージキーの共通定数化でデータ整合性を確保

## Test plan
- [ ] options page でドメインを追加・削除できる
- [ ] options page でリンク（ラベル＋URL）を追加・削除できる
- [ ] 登録後にリロードしてもデータが保持されている
- [ ] 登録済みドメインのページを開いた状態でポップアップを開くと関連リンクが表示される
- [ ] 未登録ドメインのページではポップアップに関連リンクセクションが表示されない
- [ ] `javascript:` スキームの URL は登録できない

🤖 Generated with [Claude Code](https://claude.com/claude-code)